### PR TITLE
Some code cleanup

### DIFF
--- a/rust/src/details/identifier.rs
+++ b/rust/src/details/identifier.rs
@@ -40,14 +40,14 @@ impl std::fmt::Display for Identifier {
     }
 }
 
-impl Into<String> for Identifier {
-    fn into(self) -> String {
-        self.0
+impl From<Identifier> for String {
+    fn from(val: Identifier) -> Self {
+        val.0
     }
 }
 
-impl Into<String> for &Identifier {
-    fn into(self) -> String {
-        self.0.clone()
+impl From<&Identifier> for String {
+    fn from(val: &Identifier) -> Self {
+        val.0.clone()
     }
 }

--- a/rust/src/details/identifier.rs
+++ b/rust/src/details/identifier.rs
@@ -10,7 +10,7 @@ pub struct Identifier(String);
 impl PrecomputedHash for Identifier {
     fn precomputed_hash(&self) -> u32 {
         // let Identifier(contents) = self;
-        return 0;
+        0
     }
 }
 
@@ -24,7 +24,7 @@ impl ToCss for Identifier {
 
 impl <'a> From<&'a str> for Identifier {
     fn from(value: &'a str) -> Self {
-        return Identifier(value.to_string());
+        Identifier(value.to_string())
     }
 }
 

--- a/rust/src/details/property/definitionparser.rs
+++ b/rust/src/details/property/definitionparser.rs
@@ -41,7 +41,7 @@ impl<'i> cssparser::DeclarationParser<'i> for PropertyDefinitionParser {
                         identifier.to_string()
                     },
                     cssparser::Token::Function(function) => {
-                        if function == &"var" {
+                        if function == "var" {
                             let var_function = property_function("var").unwrap();
                             let result = input.parse_nested_block(|parser| var_function(parser));
                             if let Ok(values) = result {
@@ -83,7 +83,7 @@ impl<'i> cssparser::DeclarationParser<'i> for PropertyDefinitionParser {
             "initial-value" => {
                 let value_result = parse_values(&self.definition.syntax, input);
                 if let Ok(values) = value_result {
-                    self.definition.initial = values.into();
+                    self.definition.initial = values;
                 } else {
                     return Err(value_result.err().unwrap())
                 }

--- a/rust/src/details/property/definitionparser.rs
+++ b/rust/src/details/property/definitionparser.rs
@@ -121,9 +121,9 @@ pub fn parse_property_definition<'i, 't>(
         definition: PropertyDefinition::empty(),
     };
     parser.definition.name = name;
-    let mut rule_parser = cssparser::RuleBodyParser::new(input, &mut parser);
+    let rule_parser = cssparser::RuleBodyParser::new(input, &mut parser);
 
-    while let Some(item) = rule_parser.next() {
+    for item in rule_parser {
         if let Err(error) = item {
             return Err(error.0)
         }

--- a/rust/src/details/property/function.rs
+++ b/rust/src/details/property/function.rs
@@ -32,7 +32,7 @@ pub fn property_function(name: &str) -> Option<PropertyFunction> {
         }
     }
 
-    None{}
+    None
 }
 
 #[allow(dead_code)]

--- a/rust/src/details/property/syntax.rs
+++ b/rust/src/details/property/syntax.rs
@@ -472,21 +472,21 @@ fn validate_component<'a>(component: &SyntaxComponent, values: &'a [Value], list
         SyntaxComponent::Comma => Ok(values),
         SyntaxComponent::SpaceSeparatedList(datatype) => {
             if list_type == &ListType::CommaSeparated {
-                return Err(SyntaxValidateError(format!("Expected space separated list, got comma separated")))
+                return Err(SyntaxValidateError(String::from("Expected space separated list, got comma separated")))
             }
 
-            validate_list(datatype, values, 0, usize::max_value())
+            validate_list(datatype, values, 0, usize::MAX)
         },
         SyntaxComponent::CommaSeparatedList(datatype) => {
             if list_type == &ListType::SpaceSeparated {
-                return Err(SyntaxValidateError(format!("Expected comma separated list, got space separated")))
+                return Err(SyntaxValidateError(String::from("Expected comma separated list, got space separated")))
             }
 
-            validate_list(datatype, values, 0, usize::max_value())
+            validate_list(datatype, values, 0, usize::MAX)
         },
         SyntaxComponent::Repeat { data_type, minimum, maximum } => {
             if list_type == &ListType::CommaSeparated {
-                return Err(SyntaxValidateError(format!("Expected space separated list, got comma separated")))
+                return Err(SyntaxValidateError(String::from("Expected space separated list, got comma separated")))
             }
             validate_list(data_type, values, *minimum, *maximum)
         },
@@ -510,7 +510,7 @@ fn validate_alternatives<'a>(alternatives: &SyntaxAlternatives, values: &'a [Val
                     return Ok(remain);
                 }
             }
-            Err(SyntaxValidateError(format!("None of the alternatives matched")))
+            Err(SyntaxValidateError(String::from("None of the alternatives matched")))
         }
     }
 }
@@ -540,7 +540,7 @@ fn validate_expression<'a>(expression: &[SyntaxAlternatives], values: &'a [Value
     if remaining_expression.is_empty() {
         Ok(remaining_values)
     } else {
-        Err(SyntaxValidateError(format!("Expected additional values")))
+        Err(SyntaxValidateError(String::from("Expected additional values")))
     }
 }
 

--- a/rust/src/details/property/syntax.rs
+++ b/rust/src/details/property/syntax.rs
@@ -224,12 +224,10 @@ fn repeat(input: &str) -> SyntaxParseResult<&str, SyntaxComponent> {
         )
     ).parse(input);
 
-    if let Ok((remain, (data_type, (minimum, maximum)))) = result {
-        if let SyntaxComponent::DataType(type_name) = data_type {
-            let min: usize = minimum.parse().unwrap();
-            let max: usize = maximum.parse().unwrap();
-            return Ok((remain, SyntaxComponent::Repeat{data_type: type_name, minimum: min, maximum: max}));
-        }
+    if let Ok((remain, (SyntaxComponent::DataType(type_name), (minimum, maximum)))) = result {
+        let min: usize = minimum.parse().unwrap();
+        let max: usize = maximum.parse().unwrap();
+        return Ok((remain, SyntaxComponent::Repeat{data_type: type_name, minimum: min, maximum: max}));
     }
 
     make_error(input, String::from("Input is not a valid repeat pattern"))
@@ -266,10 +264,8 @@ fn group(input: &str) -> SyntaxParseResult<&str, SyntaxGroup> {
         expression,
         delimited(space0, char(')'), space0),
     ).parse(input);
-    if let Ok((remain, result)) = expression {
-        if let ParsedPropertySyntax::Expression(exp) = result {
-            return Ok((remain, SyntaxGroup::Expression(exp)));
-        }
+    if let Ok((remain, ParsedPropertySyntax::Expression(exp))) = expression {
+        return Ok((remain, SyntaxGroup::Expression(exp)));
     }
 
     let component = component.parse(input);

--- a/rust/src/details/property/syntax.rs
+++ b/rust/src/details/property/syntax.rs
@@ -124,11 +124,7 @@ fn custom_ident_start(input: char) -> bool {
 }
 
 fn custom_ident(input: char) -> bool {
-    if custom_ident_start(input) || input.is_numeric() || input == '-' {
-        true
-    } else {
-        false
-    }
+    custom_ident_start(input) || input.is_numeric() || input == '-'
 }
 
 fn keyword(input: &str) -> SyntaxParseResult<&str, SyntaxComponent> {

--- a/rust/src/details/property/syntax.rs
+++ b/rust/src/details/property/syntax.rs
@@ -120,27 +120,7 @@ pub enum ParsedPropertySyntax {
  */
 
 fn custom_ident_start(input: char) -> bool {
-    match input {
-        'a'..='z' => true,
-        'A'..='Z' => true,
-        '_' => true,
-        '\u{00B7}' => true,
-        '\u{00CD}'..='\u{00D7}' => true,
-        '\u{00D8}'..='\u{00F6}' => true,
-        '\u{00F8}'..='\u{037D}' => true,
-        '\u{037F}'..='\u{1FFF}' => true,
-        '\u{200C}' => true,
-        '\u{200D}' => true,
-        '\u{203F}' => true,
-        '\u{2040}' => true,
-        '\u{2070}'..='\u{218F}' => true,
-        '\u{2C00}'..='\u{2FEF}' => true,
-        '\u{3001}'..='\u{D7FF}' => true,
-        '\u{F900}'..='\u{FDCF}' => true,
-        '\u{FDF0}'..='\u{FFFD}' => true,
-        '\u{10000}'..='\u{10FFFF}' => true,
-        _ => false,
-    }
+    matches!(input, 'a'..='z' | 'A'..='Z' | '_' | '\u{00B7}' | '\u{00CD}'..='\u{00D7}' | '\u{00D8}'..='\u{00F6}' | '\u{00F8}'..='\u{037D}' | '\u{037F}'..='\u{1FFF}' | '\u{200C}' | '\u{200D}' | '\u{203F}' | '\u{2040}' | '\u{2070}'..='\u{218F}' | '\u{2C00}'..='\u{2FEF}' | '\u{3001}'..='\u{D7FF}' | '\u{F900}'..='\u{FDCF}' | '\u{FDF0}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}')
 }
 
 fn custom_ident(input: char) -> bool {

--- a/rust/src/details/property/syntax.rs
+++ b/rust/src/details/property/syntax.rs
@@ -432,17 +432,14 @@ fn validate_list<'a>(datatype: &DataType, values: &'a [Value], minimum: usize, m
     let mut count = 0;
     let mut remain = values;
     while !remain.is_empty() {
-        let result = validate_datatype(datatype, remain);
-        if let Ok(validate_remain) = result {
-            count += 1;
-            remain = validate_remain;
+        let validate_remain = validate_datatype(datatype, remain)?;
 
-            if count == maximum {
-                break
-            }
-        } else {
-            return result;
-        }
+        count += 1;
+        remain = validate_remain;
+
+        if count == maximum {
+            break
+        };
     }
 
     if count < minimum {
@@ -525,12 +522,7 @@ fn validate_expression<'a>(expression: &[SyntaxAlternatives], values: &'a [Value
             break;
         }
 
-        let result = validate_alternatives(alternative, remaining_values, list_type);
-        if let Ok(remain) = result {
-            remaining_values = remain;
-        } else {
-            return result;
-        }
+        remaining_values = validate_alternatives(alternative, remaining_values, list_type)?;
     }
 
     if remaining_expression.is_empty() {

--- a/rust/src/details/property/value.rs
+++ b/rust/src/details/property/value.rs
@@ -67,7 +67,7 @@ fn parse_color<'i, 't>(parser: &mut cssparser::Parser<'i, 't>) -> ParseValueComp
         }
     }
 
-    parse_error(parser, ParseErrorKind::InvalidPropertyValue, format!("Input could not be parsed as color"))
+    parse_error(parser, ParseErrorKind::InvalidPropertyValue, String::from("Input could not be parsed as color"))
 }
 
 fn parse_number<'i, 't>(parser: &mut cssparser::Parser<'i, 't>) -> ParseValueComponentResult<'i> {

--- a/rust/src/details/property/value.rs
+++ b/rust/src/details/property/value.rs
@@ -16,12 +16,12 @@ pub(super) enum ParseValuesResult {
     CommaSeparated(Vec<Value>),
 }
 
-impl Into<Vec<Value>> for ParseValuesResult {
-    fn into(self) -> Vec<Value> {
-        match self {
-            Self::Single(values) => values,
-            Self::SpaceSeparated(values) => values,
-            Self::CommaSeparated(values) => values,
+impl From<ParseValuesResult> for Vec<Value> {
+    fn from(val: ParseValuesResult) -> Self {
+        match val {
+            ParseValuesResult::Single(values) => values,
+            ParseValuesResult::SpaceSeparated(values) => values,
+            ParseValuesResult::CommaSeparated(values) => values,
         }
     }
 }

--- a/rust/src/details/property/value.rs
+++ b/rust/src/details/property/value.rs
@@ -167,10 +167,10 @@ pub fn parse_values<'i, 't>(syntax: &ParsedPropertySyntax, parser: &mut cssparse
 
     if let Ok(values) = result {
         let validation_result = validate_syntax(syntax, &values, SourceLocation::from_file_location(parser.current_source_url().unwrap_or("").to_string(), parser.current_source_location()));
-        if let Ok(_) = validation_result {
-            Ok(values.into())
-        } else {
-            Err(parser.new_custom_error(validation_result.unwrap_err()))
+
+        match validation_result {
+            Ok(_) => Ok(values.into()),
+            Err(e) => Err(parser.new_custom_error(e)),
         }
     } else {
         Err(result.err().unwrap())

--- a/rust/src/details/property/value.rs
+++ b/rust/src/details/property/value.rs
@@ -35,15 +35,15 @@ fn parse_dimension<'i, 't>(parser: &mut cssparser::Parser<'i, 't>) -> ParseValue
             let unit = Unit::parse(unit_string.to_string().as_str());
             match unit {
                 Unit::Unknown | Unit::Unsupported => {
-                    return parse_error(parser, ParseErrorKind::InvalidPropertyValue, format!("Invalid unit for dimension: {}", unit_string));
+                    parse_error(parser, ParseErrorKind::InvalidPropertyValue, format!("Invalid unit for dimension: {}", unit_string))
                 }
                 _ => {
-                    return Ok(Value::from(Dimension{value, unit}));
+                    Ok(Value::from(Dimension{value, unit}))
                 }
             }
         },
         cssparser::Token::Percentage { has_sign: _, unit_value, int_value: _ } => {
-            return Ok(Value::from(Dimension{value: unit_value, unit: Unit::Percent}))
+            Ok(Value::from(Dimension{value: unit_value, unit: Unit::Percent}))
         },
         _ => parse_error(parser, ParseErrorKind::InvalidPropertyValue, String::from("Expected a dimension"))
     }
@@ -84,10 +84,10 @@ fn parse_string<'i, 't>(parser: &mut cssparser::Parser<'i, 't>) -> ParseValueCom
     let token = parser.next()?.clone();
     match token {
         cssparser::Token::Ident(value) => {
-            return Ok(Value::from(value.as_ref()))
+            Ok(Value::from(value.as_ref()))
         },
         cssparser::Token::QuotedString(value) => {
-            return Ok(Value::from(value.as_ref()))
+            Ok(Value::from(value.as_ref()))
         }
         _ => {
             parse_error(parser, ParseErrorKind::InvalidPropertyValue, format!("Unexpected token {:?}", token))
@@ -97,7 +97,7 @@ fn parse_string<'i, 't>(parser: &mut cssparser::Parser<'i, 't>) -> ParseValueCom
 
 fn parse_url<'i, 't>(parser: &mut cssparser::Parser<'i, 't>) -> ParseValueComponentResult<'i> {
     let url = parser.expect_url()?;
-    return Ok(Value::new_url(url.as_ref()));
+    Ok(Value::new_url(url.as_ref()))
 }
 
 fn parse_function<'i, 't>(parser: &mut cssparser::Parser<'i, 't>) -> Result<Vec<Value>, cssparser::ParseError<'i, ParseError>> {

--- a/rust/src/details/property/value.rs
+++ b/rust/src/details/property/value.rs
@@ -104,14 +104,7 @@ fn parse_function<'i, 't>(parser: &mut cssparser::Parser<'i, 't>) -> Result<Vec<
     let function_name = parser.expect_function()?.to_string();
 
     if let Some(func) = property_function(function_name.as_ref()) {
-        parser.parse_nested_block(|parser| {
-            let output = func(parser);
-            if let Ok(output_ok) = output {
-                Ok(output_ok)
-            } else {
-                return output;
-            }
-        })
+        parser.parse_nested_block(func)
     } else {
         parse_error(parser, ParseErrorKind::UnknownFunction, format!("Unknown function {:?}", function_name))
     }

--- a/rust/src/details/property/value.rs
+++ b/rust/src/details/property/value.rs
@@ -158,7 +158,7 @@ pub fn parse_values<'i, 't>(syntax: &ParsedPropertySyntax, parser: &mut cssparse
                 return Err(result.err().unwrap());
             }
 
-            if let Ok(_) = parser.try_parse(|parser| { parser.expect_comma() }) {
+            if parser.try_parse(|parser| { parser.expect_comma() }).is_ok() {
                 comma_separated = true;
             }
         }

--- a/rust/src/details/rulesparser.rs
+++ b/rust/src/details/rulesparser.rs
@@ -104,11 +104,11 @@ impl<'i, const TOP_LEVEL: bool> cssparser::AtRuleParser<'i> for RulesParser<TOP_
         let name_string = name.to_string();
         match name_string.as_str() {
             "property" => {
-                return Ok(AtRulePrelude::Property(input.expect_ident()?.to_string()));
+                Ok(AtRulePrelude::Property(input.expect_ident()?.to_string()))
             },
             "import" => {
                 let url = input.expect_url_or_string()?.to_string();
-                return Ok(AtRulePrelude::Import(url));
+                Ok(AtRulePrelude::Import(url))
             }
             _ => parse_error(input, ParseErrorKind::UnsupportedAtRule, format!("Unsupported @-rule {}", name)),
         }
@@ -124,12 +124,12 @@ impl<'i, const TOP_LEVEL: bool> cssparser::AtRuleParser<'i> for RulesParser<TOP_
             AtRulePrelude::Property(name) => {
                 let result = parse_property_definition(input, name.to_string());
                 match result {
-                    Ok(definition) => return Ok(ParseResult::PropertyDefinition(definition)),
-                    Err(error) => return parse_error(input, ParseErrorKind::InvalidPropertyDefinition, error.to_string())
+                    Ok(definition) => Ok(ParseResult::PropertyDefinition(definition)),
+                    Err(error) => parse_error(input, ParseErrorKind::InvalidPropertyDefinition, error.to_string())
                 }
             },
             _ => {
-                return parse_error(input, ParseErrorKind::UnsupportedAtRule, format!("Got @-rule: {:?}", prelude));
+                parse_error(input, ParseErrorKind::UnsupportedAtRule, format!("Got @-rule: {:?}", prelude))
             }
         }
     }
@@ -141,10 +141,10 @@ impl<'i, const TOP_LEVEL: bool> cssparser::AtRuleParser<'i> for RulesParser<TOP_
     ) -> Result<Self::AtRule, ()> {
         match prelude {
             AtRulePrelude::Import(url) => {
-                return Ok(ParseResult::Import(url))
+                Ok(ParseResult::Import(url))
             },
             _ => {
-                return Err(())
+                Err(())
             }
         }
     }

--- a/rust/src/details/rulesparser.rs
+++ b/rust/src/details/rulesparser.rs
@@ -64,11 +64,11 @@ impl<'i, const TOP_LEVEL: bool> cssparser::QualifiedRuleParser<'i> for RulesPars
         parser: &mut cssparser::Parser<'i, 't>) -> Result<Self::QualifiedRule, cssparser::ParseError<'i, Self::Error>>
     {
         let mut nested_parser = NestedParser{};
-        let mut body_parser = RuleBodyParser::<NestedParser, Self::QualifiedRule, Self::Error>::new(parser, &mut nested_parser);
+        let body_parser = RuleBodyParser::<NestedParser, Self::QualifiedRule, Self::Error>::new(parser, &mut nested_parser);
 
         let mut properties = Vec::new();
         let mut nested = Vec::new();
-        while let Some(entry) = body_parser.next() {
+        for entry in body_parser {
             if let Ok(entry_contents) = entry {
                 match entry_contents {
                     ParseResult::Property(property) => properties.push(property),

--- a/rust/src/details/selectorparser.rs
+++ b/rust/src/details/selectorparser.rs
@@ -31,17 +31,17 @@ impl selectors::parser::NonTSPseudoClass for PseudoClass {
     type Impl = SelectorImpl;
 
     fn is_active_or_hover(&self) -> bool {
-        return false;
+        false
     }
 
     fn is_user_action_state(&self) -> bool {
-        return false;
+        false
     }
 
     fn visit<V>(&self, _visitor: &mut V) -> bool
     where
         V: selectors::parser::SelectorVisitor<Impl = Self::Impl>, {
-        return true;
+        true
     }
 }
 
@@ -148,7 +148,7 @@ impl SelectorParser {
             selectors.push(selector);
         }
 
-        return Ok(selectors);
+        Ok(selectors)
     }
 }
 

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-2.1-only OR LGPL-3.0-only OR LicenseRef-KDE-Accepted-LGPL
 // SPDX-FileCopyrightText: 2025 Arjen Hiemstra <ahiemstra@heimr.nl>
 
+use std::fmt::Display;
+
 use ffi::ValueConversionError;
 
 use crate::selector::{Selector, SelectorPart, SelectorKind, SelectorValue};
@@ -211,15 +213,15 @@ impl From<&value::Color> for ffi::Color {
     }
 }
 
-impl ffi::Color {
-    fn to_string(&self) -> String {
-        format!("#{:02x}{:02x}{:02x}{:02x}", self.r, self.g, self.b, self.a)
+impl Display for ffi::Color {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("#{:02x}{:02x}{:02x}{:02x}", self.r, self.g, self.b, self.a))
     }
 }
 
-impl ffi::Dimension {
-    fn to_string(&self) -> String {
-        format!("{}{:?}", self.value, self.unit)
+impl Display for ffi::Dimension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{}{:?}", self.value, self.unit))
     }
 }
 

--- a/rust/src/property.rs
+++ b/rust/src/property.rs
@@ -36,7 +36,7 @@ pub fn property_definition(name: &str) -> Option<Arc<PropertyDefinition>> {
 pub fn add_property_definition(definition: &Arc<PropertyDefinition>) -> bool {
     let defs = property_definitions().write();
     if let Ok(mut definitions) = defs {
-        if definitions.iter().find(|&def| def.name == definition.name).is_some() {
+        if definitions.iter().any(|def| def.name == definition.name) {
             return false;
         }
 

--- a/rust/src/selector.rs
+++ b/rust/src/selector.rs
@@ -53,7 +53,7 @@ impl SelectorPart {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Selector {
     pub parts: Vec<SelectorPart>,
 }

--- a/rust/src/stylerule.rs
+++ b/rust/src/stylerule.rs
@@ -29,7 +29,7 @@ impl StyleRule {
             for nested_rule in &parsed.nested_rules {
                 for nested_result in StyleRule::from_parsed_rule(nested_rule) {
                     result.push(Self {
-                        selector: Selector::combine(&nested_result.selector, &selector),
+                        selector: Selector::combine(&nested_result.selector, selector),
                         properties: nested_result.properties,
                     });
                 }

--- a/rust/src/stylesheet.rs
+++ b/rust/src/stylesheet.rs
@@ -12,7 +12,7 @@ use crate::details::rulesparser::*;
 use crate::property::add_property_definition;
 use crate::stylerule::*;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct StyleSheet {
     pub rules: Vec<StyleRule>,
     pub errors: Vec<ParseError>,

--- a/rust/src/tests/propertyfunction.rs
+++ b/rust/src/tests/propertyfunction.rs
@@ -11,14 +11,7 @@ fn check_value(input: &str, expected: Vec<Value>) {
     let function_name = parser.expect_function().unwrap().as_ref();
     let function = property_function(function_name).unwrap();
 
-    let result = parser.parse_nested_block(|parser| {
-        let output = function(parser);
-        if let Ok(output_ok) = output {
-            Ok(output_ok)
-        } else {
-            return output;
-        }
-    });
+    let result = parser.parse_nested_block(function);
 
     match result {
         Ok(values) => assert_eq!(values, expected),

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -112,10 +112,7 @@ impl Dimension {
     }
 
     pub fn is_length(&self) -> bool {
-        match self.unit {
-            Unit::Px | Unit::Em | Unit::Rem | Unit::Pt => true,
-            _ => false,
-        }
+        matches!(self.unit, Unit::Px | Unit::Em | Unit::Rem | Unit::Pt)
     }
 
     pub fn is_percent(&self) -> bool {
@@ -123,10 +120,7 @@ impl Dimension {
     }
 
     pub fn is_angle(&self) -> bool {
-        match self.unit {
-            Unit::Degrees | Unit::Radians => true,
-            _ => false
-        }
+        matches!(self.unit, Unit::Degrees | Unit::Radians)
     }
 }
 

--- a/rust/tests/stylesheet.rs
+++ b/rust/tests/stylesheet.rs
@@ -44,7 +44,7 @@ fn property_registration() {
     let property_definition = property_definition("test").unwrap();
 
     let result = stylesheet.parse_string("example { test: red; }", "Test Input");
-    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap().to_string());
+    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap());
 
     assert_eq!(
         stylesheet.rules,
@@ -82,7 +82,7 @@ fn custom_properties() {
         example {
             test: var(--test-color);
         }", "Test Input");
-    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap().to_string());
+    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap());
 
     let color_definition = property_definition("--test-color").unwrap();
     assert_eq!(*color_definition, PropertyDefinition::from_name_syntax_initial("--test-color", "*", &[Value::from(Color{r: 255, g: 0, b: 0, a: 255})], "Test Input", 0, 0).unwrap());
@@ -132,7 +132,7 @@ fn nested_block() {
                 test: blue;
             }
         }", "Test Input");
-    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap().to_string());
+    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap());
 
     let expected = Vec::from([
         StyleRule {
@@ -180,7 +180,7 @@ fn nested_block() {
             test: blue;
         }
     }", "Test Input");
-    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap().to_string());
+    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap());
 
     let rules = &stylesheet.rules;
     assert_eq!(rules.len(), expected.len());
@@ -193,7 +193,7 @@ fn complex() {
     stylesheet.root_path = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data"));
 
     let result = stylesheet.parse_file("complex.css");
-    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap().to_string());
+    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap());
 
     let rules = &stylesheet.rules;
     assert_eq!(rules.len(), 6);
@@ -291,7 +291,7 @@ fn import() {
     stylesheet.root_path = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data"));
 
     let result = stylesheet.parse_file("import.css");
-    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap().to_string());
+    assert!(result.is_ok(), "Parsing stylesheet failed with error: {}", result.err().unwrap());
 
     let rules = stylesheet.rules;
     assert_eq!(rules.len(), 4);


### PR DESCRIPTION
Hi all, I spent my time at Akademy reading a bit through cxx-rust-cssparser, finding some things that I felt are minimally invasive, but useful to clean up.

This is a series of patching applying small code change that move the code more towards what could be considered idiomatic Rust style. I used clippy as a guidance, but went beyond the suggestions, rather editing code in a way that straightens it and hopefully makes it clearer.

I omitted a applying rustfmt (cargo fmt), though I'd like to state that it provides a good suggestion set.